### PR TITLE
updated github install instruction

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,8 +64,8 @@ If you have the devtools package installed, you can do:
     > install.packages("rJava") # if not present already
     > install.packages("devtools") # if not present already
     > library(devtools)
-    > install_github("rrdf", "egonw", subdir="rrdflibs")
-    > install_github("rrdf", "egonw", subdir="rrdf", build_vignettes = FALSE)
+    > install_github("egonw/rrdf", subdir="rrdflibs")
+    > install_github("egonw/rrdf", subdir="rrdf", build_vignettes = FALSE)
 
 # Compile from source
 


### PR DESCRIPTION
Installation instruction still uses ‘username’ argument which is depricated
and gives a warning:
“Username parameter is deprecated. Please use egonw/rrdf“
README.md adjusted accordingly